### PR TITLE
examples: set crtc/connector properties

### DIFF
--- a/example/common.h
+++ b/example/common.h
@@ -16,6 +16,9 @@ drmModeConnector *pick_connector(int drm_fd, drmModeRes *drm_res);
 drmModeCrtc *pick_crtc(int drm_fd, drmModeRes *drm_res,
 		       drmModeConnector *connector);
 void disable_all_crtcs_except(int drm_fd, drmModeRes *drm_res, uint32_t crtc_id);
+bool set_global_properties(int drm_fd, drmModeAtomicReq *req,
+			   const drmModeConnector *connector, const drmModeCrtc *crtc,
+			   const drmModeModeInfo *mode);
 
 bool dumb_fb_init(struct dumb_fb *fb, int drm_fd, uint32_t format,
 		  uint32_t width, uint32_t height);

--- a/example/compositor.c
+++ b/example/compositor.c
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "no connector found\n");
 		return 1;
 	}
-	if (crtc == NULL || !crtc->mode_valid) {
+	if (crtc == NULL) {
 		fprintf(stderr, "no CRTC found\n");
 		return 1;
 	}
@@ -175,11 +175,11 @@ int main(int argc, char *argv[])
 	printf("Using connector %d, CRTC %d\n", connector->connector_id,
 	       crtc->crtc_id);
 
-	composition_layer = add_layer(drm_fd, output, 0, 0, crtc->mode.hdisplay,
-				      crtc->mode.vdisplay, false, true,
+	composition_layer = add_layer(drm_fd, output, 0, 0, connector->modes[0].hdisplay,
+				      connector->modes[0].vdisplay, false, true,
 				      &composition_fb);
-	layers[0] = add_layer(drm_fd, output, 0, 0, crtc->mode.hdisplay,
-			      crtc->mode.vdisplay, false, true, &fbs[0]);
+	layers[0] = add_layer(drm_fd, output, 0, 0, connector->modes[0].hdisplay,
+			      connector->modes[0].vdisplay, false, true, &fbs[0]);
 	for (i = 1; i < layers_len; i++) {
 		layers[i] = add_layer(drm_fd, output, 100 * i, 100 * i,
 				      256, 256, i % 2, false, &fbs[i]);
@@ -206,7 +206,9 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	ret = drmModeAtomicCommit(drm_fd, req, DRM_MODE_ATOMIC_NONBLOCK, NULL);
+	set_global_properties(drm_fd, req, connector, crtc, &connector->modes[0]);
+
+	ret = drmModeAtomicCommit(drm_fd, req, DRM_MODE_ATOMIC_NONBLOCK | DRM_MODE_ATOMIC_ALLOW_MODESET, NULL);
 	if (ret < 0) {
 		perror("drmModeAtomicCommit");
 		return false;

--- a/example/simple.c
+++ b/example/simple.c
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "no connector found\n");
 		return 1;
 	}
-	if (crtc == NULL || !crtc->mode_valid) {
+	if (crtc == NULL) {
 		fprintf(stderr, "no CRTC found\n");
 		return 1;
 	}
@@ -116,8 +116,8 @@ int main(int argc, char *argv[])
 	printf("Using connector %d, CRTC %d\n", connector->connector_id,
 	       crtc->crtc_id);
 
-	layers[0] = add_layer(drm_fd, output, 0, 0, crtc->mode.hdisplay,
-			      crtc->mode.vdisplay, false);
+	layers[0] = add_layer(drm_fd, output, 0, 0, connector->modes[0].hdisplay,
+			      connector->modes[0].vdisplay, false);
 	for (i = 1; i < LAYERS_LEN; i++) {
 		layers[i] = add_layer(drm_fd, output, 100 * i, 100 * i,
 				      256, 256, i % 2);
@@ -133,7 +133,9 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	ret = drmModeAtomicCommit(drm_fd, req, DRM_MODE_ATOMIC_NONBLOCK, NULL);
+	set_global_properties(drm_fd, req, connector, crtc, &connector->modes[0]);
+
+	ret = drmModeAtomicCommit(drm_fd, req, DRM_MODE_ATOMIC_NONBLOCK | DRM_MODE_ATOMIC_ALLOW_MODESET, NULL);
 	if (ret < 0) {
 		perror("drmModeAtomicCommit");
 		return false;


### PR DESCRIPTION
The behind-the-scenes manipulation of the per-plane DRM properties
needs to be augmented with some singleton property assignments
too (what CRTC should the connector be driving? what mode should
be used? is the CRC on?).

Also use DRM_MODE_ATOMIC_ALLOW_MODESET in the live commit in
case the new configuration doesn't match with whatever set of
modes and color formats the previous DRM master happened to use.