### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
 	'c',
 	version: '0.0.0',
 	license: 'MIT',
-	meson_version: '>=0.47.0',
+	meson_version: '>=0.52.0',
 	default_options: [
 		'c_std=c99',
 		'warning_level=3',
@@ -20,7 +20,7 @@ add_project_arguments(cc.get_supported_arguments([
 
 liftoff_inc = include_directories('include')
 
-drm = dependency('libdrm')
+drm = dependency('libdrm', include_type: 'system')
 
 liftoff_deps = [drm]
 

--- a/test/bench.c
+++ b/test/bench.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 200112
+#define _POSIX_C_SOURCE 200112L
 #include <assert.h>
 #include <libliftoff.h>
 #include <stdio.h>

--- a/test/bench.c
+++ b/test/bench.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200112
 #include <assert.h>
 #include <libliftoff.h>
 #include <stdio.h>


### PR DESCRIPTION
- [POSIX says](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/time.h.html) `CLOCK_MONOTONIC` was introduced in Issue 6
- BSDs don't search headers from packages by default but pkg-config uses `-I` which trips `-Werror`

```
$ meson setup _build && meson compile -C _build && meson test -C _build
[...]
Ok:                 30
Expected Fail:      0
Fail:               0
Unexpected Pass:    0
Skipped:            0
Timeout:            0

$ vidcontrol -s 1 </dev/ttyv0
$ for f (_build/example/*(*)) { echo "==> Running $f:t"; ./$f; echo; }
==> Running compositor
Using connector 99, CRTC 48
Created FB 116 with size 3840x2160
Created FB 118 with size 3840x2160
Created FB 119 with size 256x256
Created FB 120 with size 256x256
Created FB 121 with size 256x256
Created FB 122 with size 256x256
Created FB 123 with size 256x256
Composition layer got assigned to plane 0
Layer 0 got assigned to plane 0
Layer 1 got assigned to plane 0
Layer 2 got assigned to plane 0
Layer 3 got assigned to plane 0
Layer 4 got assigned to plane 0
Layer 5 got assigned to plane 0

==> Running dynamic
Using connector 99, CRTC 48
drmModeAtomicCommit: Invalid argument
poll: Invalid argument

==> Running multi-output
Using connector 99, CRTC 48
Created FB 116 with size 3840x2160
Created FB 118 with size 256x256
Created FB 119 with size 256x256
Created FB 120 with size 256x256
drmModeAtomicCommit: Invalid argument

==> Running simple
Using connector 99, CRTC 48
Created FB 117 with size 3840x2160
Created FB 118 with size 256x256
Created FB 119 with size 256x256
Created FB 120 with size 256x256
drmModeAtomicCommit: Invalid argument
```
