### PR TITLE
Allow to choose which planes are managed by libliftoff

### DIFF
--- a/example/compositor.c
+++ b/example/compositor.c
@@ -153,6 +153,8 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	liftoff_device_register_all_planes(device);
+
 	drm_res = drmModeGetResources(drm_fd);
 	connector = pick_connector(drm_fd, drm_res);
 	crtc = pick_crtc(drm_fd, drm_res, connector);

--- a/example/dynamic.c
+++ b/example/dynamic.c
@@ -162,6 +162,8 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	liftoff_device_register_all_planes(device);
+
 	drm_res = drmModeGetResources(drm_fd);
 	connector = pick_connector(drm_fd, drm_res);
 	crtc = pick_crtc(drm_fd, drm_res, connector);

--- a/example/multi-output.c
+++ b/example/multi-output.c
@@ -97,6 +97,8 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	liftoff_device_register_all_planes(device);
+
 	drm_res = drmModeGetResources(drm_fd);
 
 	outputs_len = 0;

--- a/example/simple.c
+++ b/example/simple.c
@@ -94,6 +94,8 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	liftoff_device_register_all_planes(device);
+
 	drm_res = drmModeGetResources(drm_fd);
 	connector = pick_connector(drm_fd, drm_res);
 	crtc = pick_crtc(drm_fd, drm_res, connector);

--- a/include/libliftoff.h
+++ b/include/libliftoff.h
@@ -10,6 +10,7 @@
 struct liftoff_device;
 struct liftoff_output;
 struct liftoff_layer;
+struct liftoff_plane;
 
 /**
  * Initialize libliftoff for a DRM node.
@@ -23,6 +24,28 @@ struct liftoff_device *liftoff_device_create(int drm_fd);
  * The caller is expected to destroy the outputs and layers explicitly.
  */
 void liftoff_device_destroy(struct liftoff_device *device);
+/**
+ * Register all available hardware planes to be managed by the libliftoff
+ * device.
+ *
+ * Users should call this function if they don't manually set any plane property
+ * and instead use libliftoff layers.
+ */
+bool liftoff_device_register_all_planes(struct liftoff_device *device);
+
+/**
+ * Register a hardware plane to be managed by the libliftoff device.
+ *
+ * Users should call this function for each plane they don't want to manually
+ * manage. Registering the same plane twice is an error.
+ */
+struct liftoff_plane *liftoff_plane_create(struct liftoff_device *device,
+					   uint32_t plane_id);
+/**
+ * Unregister a hardware plane.
+ */
+void liftoff_plane_destroy(struct liftoff_plane *plane);
+
 /**
  * Build a layer to plane mapping and append the plane configuration to `req`.
  *

--- a/include/private.h
+++ b/include/private.h
@@ -92,8 +92,6 @@ void layer_mark_clean(struct liftoff_layer *layer);
 void layer_update_priority(struct liftoff_layer *layer, bool make_current);
 bool layer_has_fb(struct liftoff_layer *layer);
 
-struct liftoff_plane *plane_create(struct liftoff_device *device, uint32_t id);
-void plane_destroy(struct liftoff_plane *plane);
 struct liftoff_plane_property *plane_get_property(struct liftoff_plane *plane,
 						  const char *name);
 bool plane_apply(struct liftoff_plane *plane, struct liftoff_layer *layer,

--- a/plane.c
+++ b/plane.c
@@ -30,7 +30,8 @@ static int guess_plane_zpos_from_type(struct liftoff_device *device,
 	return 0;
 }
 
-struct liftoff_plane *plane_create(struct liftoff_device *device, uint32_t id)
+struct liftoff_plane *liftoff_plane_create(struct liftoff_device *device,
+					   uint32_t id)
 {
 	struct liftoff_plane *plane, *cur;
 	drmModePlane *drm_plane;
@@ -40,6 +41,14 @@ struct liftoff_plane *plane_create(struct liftoff_device *device, uint32_t id)
 	struct liftoff_plane_property *prop;
 	uint64_t value;
 	bool has_type = false, has_zpos = false;
+
+	liftoff_list_for_each(plane, &device->planes, link) {
+		if (plane->id == id) {
+			liftoff_log(LIFTOFF_ERROR, "tried to register plane "
+				    "%"PRIu32" twice\n", id);
+			return NULL;
+		}
+	}
 
 	plane = calloc(1, sizeof(*plane));
 	if (plane == NULL) {
@@ -128,7 +137,7 @@ struct liftoff_plane *plane_create(struct liftoff_device *device, uint32_t id)
 	return plane;
 }
 
-void plane_destroy(struct liftoff_plane *plane)
+void liftoff_plane_destroy(struct liftoff_plane *plane)
 {
 	if (plane->layer != NULL) {
 		plane->layer->plane = NULL;

--- a/test/bench.c
+++ b/test/bench.c
@@ -76,6 +76,8 @@ int main(int argc, char *argv[])
 	device = liftoff_device_create(drm_fd);
 	assert(device != NULL);
 
+	liftoff_device_register_all_planes(device);
+
 	output = liftoff_output_create(device, liftoff_mock_drm_crtc_id);
 
 	for (i = 0; i < layers_len; i++) {

--- a/test/test_alloc.c
+++ b/test/test_alloc.c
@@ -618,6 +618,8 @@ static void run_test(struct test_layer *test_layers)
 	device = liftoff_device_create(drm_fd);
 	assert(device != NULL);
 
+	liftoff_device_register_all_planes(device);
+
 	output = liftoff_output_create(device, liftoff_mock_drm_crtc_id);
 	for (i = 0; test_layers[i].width > 0; i++) {
 		test_layer = &test_layers[i];
@@ -701,6 +703,8 @@ static void test_basic(void)
 	device = liftoff_device_create(drm_fd);
 	assert(device != NULL);
 
+	liftoff_device_register_all_planes(device);
+
 	output = liftoff_output_create(device, liftoff_mock_drm_crtc_id);
 	layer = add_layer(output, 0, 0, 1920, 1080);
 
@@ -736,6 +740,8 @@ static void test_no_fb_fail(bool zero_fb_id)
 	drm_fd = liftoff_mock_drm_open();
 	device = liftoff_device_create(drm_fd);
 	assert(device != NULL);
+
+	liftoff_device_register_all_planes(device);
 
 	output = liftoff_output_create(device, liftoff_mock_drm_crtc_id);
 	layer = liftoff_layer_create(output);
@@ -776,6 +782,8 @@ static void test_composition_zero_fb(void)
 	drm_fd = liftoff_mock_drm_open();
 	device = liftoff_device_create(drm_fd);
 	assert(device != NULL);
+
+	liftoff_device_register_all_planes(device);
 
 	output = liftoff_output_create(device, liftoff_mock_drm_crtc_id);
 	composition_layer = add_layer(output, 0, 0, 1920, 1080);

--- a/test/test_dynamic.c
+++ b/test/test_dynamic.c
@@ -291,6 +291,8 @@ static void run(const struct test_case *test) {
 	device = liftoff_device_create(ctx.drm_fd);
 	assert(device != NULL);
 
+	liftoff_device_register_all_planes(device);
+
 	ctx.output = liftoff_output_create(device, liftoff_mock_drm_crtc_id);
 	ctx.layer = add_layer(ctx.output, 0, 0, 1920, 1080);
 	/* Layers incompatible with all planes */

--- a/test/test_priority.c
+++ b/test/test_priority.c
@@ -50,6 +50,8 @@ int main(int argc, char *argv[]) {
 	device = liftoff_device_create(drm_fd);
 	assert(device != NULL);
 
+	liftoff_device_register_all_planes(device);
+
 	output = liftoff_output_create(device, liftoff_mock_drm_crtc_id);
 	layers[0] = add_layer(output, 0, 0, 1920, 1080);
 	layers[1] = add_layer(output, 0, 0, 1920, 1080);

--- a/test/test_prop.c
+++ b/test/test_prop.c
@@ -68,6 +68,8 @@ static int test_prop_default(const char *prop_name)
 	device = liftoff_device_create(drm_fd);
 	assert(device != NULL);
 
+	liftoff_device_register_all_planes(device);
+
 	output = liftoff_output_create(device, liftoff_mock_drm_crtc_id);
 	layer = add_layer(output, 0, 0, 1920, 1080);
 
@@ -145,6 +147,8 @@ static int test_ignore_alpha(void)
 	device = liftoff_device_create(drm_fd);
 	assert(device != NULL);
 
+	liftoff_device_register_all_planes(device);
+
 	output = liftoff_output_create(device, liftoff_mock_drm_crtc_id);
 	layer = add_layer(output, 0, 0, 1920, 1080);
 	liftoff_layer_set_property(layer, "alpha", 0); /* fully transparent */
@@ -194,6 +198,8 @@ static int test_immutable_zpos(void) {
 	drm_fd = liftoff_mock_drm_open();
 	device = liftoff_device_create(drm_fd);
 	assert(device != NULL);
+
+	liftoff_device_register_all_planes(device);
 
 	output = liftoff_output_create(device, liftoff_mock_drm_crtc_id);
 	layer1 = add_layer(output, 0, 0, 256, 256);


### PR DESCRIPTION
Closes: https://github.com/emersion/libliftoff/issues/10

- Should we expose `struct liftoff_plane` at all? Maybe easier to just use plane IDs everywhere in the public API
- Should registering/unregistering twice be an error?