### PR TITLE
Introduce core properties

### DIFF
--- a/alloc.c
+++ b/alloc.c
@@ -125,7 +125,7 @@ plane_step_init_next(struct alloc_step *step, struct alloc_step *prev,
 
 	zpos_prop = NULL;
 	if (layer != NULL) {
-		zpos_prop = layer_get_property(layer, "zpos");
+		zpos_prop = layer_get_property(layer, LIFTOFF_PROP_ZPOS);
 	}
 	if (zpos_prop != NULL && plane->type != DRM_PLANE_TYPE_PRIMARY) {
 		step->last_layer_zpos = zpos_prop->value;
@@ -168,7 +168,7 @@ has_composited_layer_over(struct liftoff_output *output,
 	struct liftoff_layer *other_layer;
 	struct liftoff_layer_property *zpos_prop, *other_zpos_prop;
 
-	zpos_prop = layer_get_property(layer, "zpos");
+	zpos_prop = layer_get_property(layer, LIFTOFF_PROP_ZPOS);
 	if (zpos_prop == NULL) {
 		return false;
 	}
@@ -178,7 +178,8 @@ has_composited_layer_over(struct liftoff_output *output,
 			continue;
 		}
 
-		other_zpos_prop = layer_get_property(other_layer, "zpos");
+		other_zpos_prop = layer_get_property(other_layer,
+						     LIFTOFF_PROP_ZPOS);
 		if (other_zpos_prop == NULL) {
 			continue;
 		}
@@ -201,7 +202,7 @@ has_allocated_layer_over(struct liftoff_output *output, struct alloc_step *step,
 	struct liftoff_layer *other_layer;
 	struct liftoff_layer_property *zpos_prop, *other_zpos_prop;
 
-	zpos_prop = layer_get_property(layer, "zpos");
+	zpos_prop = layer_get_property(layer, LIFTOFF_PROP_ZPOS);
 	if (zpos_prop == NULL) {
 		return false;
 	}
@@ -221,7 +222,8 @@ has_allocated_layer_over(struct liftoff_output *output, struct alloc_step *step,
 			continue;
 		}
 
-		other_zpos_prop = layer_get_property(other_layer, "zpos");
+		other_zpos_prop = layer_get_property(other_layer,
+						     LIFTOFF_PROP_ZPOS);
 		if (other_zpos_prop == NULL) {
 			continue;
 		}
@@ -284,7 +286,7 @@ check_layer_plane_compatible(struct alloc_step *step,
 		return false;
 	}
 
-	zpos_prop = layer_get_property(layer, "zpos");
+	zpos_prop = layer_get_property(layer, LIFTOFF_PROP_ZPOS);
 	if (zpos_prop != NULL) {
 		if ((int)zpos_prop->value > step->last_layer_zpos &&
 		    has_allocated_layer_over(output, step, layer)) {

--- a/device.c
+++ b/device.c
@@ -111,3 +111,36 @@ device_test_commit(struct liftoff_device *device, drmModeAtomicReq *req,
 
 	return ret;
 }
+
+ssize_t
+core_property_index(const char *name)
+{
+	if (strcmp(name, "FB_ID") == 0) {
+		return LIFTOFF_PROP_FB_ID;
+	} else if (strcmp(name, "CRTC_ID") == 0) {
+		return LIFTOFF_PROP_CRTC_ID;
+	} else if (strcmp(name, "CRTC_X") == 0) {
+		return LIFTOFF_PROP_CRTC_X;
+	} else if (strcmp(name, "CRTC_Y") == 0) {
+		return LIFTOFF_PROP_CRTC_Y;
+	} else if (strcmp(name, "CRTC_W") == 0) {
+		return LIFTOFF_PROP_CRTC_W;
+	} else if (strcmp(name, "CRTC_H") == 0) {
+		return LIFTOFF_PROP_CRTC_H;
+	} else if (strcmp(name, "SRC_X") == 0) {
+		return LIFTOFF_PROP_SRC_X;
+	} else if (strcmp(name, "SRC_Y") == 0) {
+		return LIFTOFF_PROP_SRC_Y;
+	} else if (strcmp(name, "SRC_W") == 0) {
+		return LIFTOFF_PROP_SRC_W;
+	} else if (strcmp(name, "SRC_H") == 0) {
+		return LIFTOFF_PROP_SRC_H;
+	} else if (strcmp(name, "zpos") == 0) {
+		return LIFTOFF_PROP_ZPOS;
+	} else if (strcmp(name, "alpha") == 0) {
+		return LIFTOFF_PROP_ALPHA;
+	} else if (strcmp(name, "rotation") == 0) {
+		return LIFTOFF_PROP_ROTATION;
+	}
+	return -1;
+}

--- a/include/private.h
+++ b/include/private.h
@@ -2,12 +2,35 @@
 #define PRIVATE_H
 
 #include <libliftoff.h>
+#include <sys/types.h>
 #include "list.h"
 #include "log.h"
 
 /* Layer priority is assigned depending on the number of updates during a
  * given number of page-flips */
 #define LIFTOFF_PRIORITY_PERIOD 60
+
+/**
+ * List of well-known KMS properties.
+ *
+ * Keep core_property_index in sync.
+ */
+enum liftoff_core_property {
+	LIFTOFF_PROP_FB_ID,
+	LIFTOFF_PROP_CRTC_ID,
+	LIFTOFF_PROP_CRTC_X,
+	LIFTOFF_PROP_CRTC_Y,
+	LIFTOFF_PROP_CRTC_W,
+	LIFTOFF_PROP_CRTC_H,
+	LIFTOFF_PROP_SRC_X,
+	LIFTOFF_PROP_SRC_Y,
+	LIFTOFF_PROP_SRC_W,
+	LIFTOFF_PROP_SRC_H,
+	LIFTOFF_PROP_ZPOS,
+	LIFTOFF_PROP_ALPHA,
+	LIFTOFF_PROP_ROTATION,
+	LIFTOFF_PROP_LAST, /* keep last */
+};
 
 struct liftoff_device {
 	int drm_fd;
@@ -43,6 +66,7 @@ struct liftoff_layer {
 
 	struct liftoff_layer_property *props;
 	size_t props_len;
+	ssize_t core_props[LIFTOFF_PROP_LAST];
 
 	bool force_composition; /* FB needs to be composited */
 
@@ -56,6 +80,7 @@ struct liftoff_layer {
 struct liftoff_layer_property {
 	char name[DRM_PROP_NAME_LEN];
 	uint64_t value, prev_value;
+	ssize_t core_index;
 };
 
 struct liftoff_plane {
@@ -68,6 +93,7 @@ struct liftoff_plane {
 
 	struct liftoff_plane_property *props;
 	size_t props_len;
+	struct liftoff_plane_property *core_props[LIFTOFF_PROP_LAST];
 
 	struct liftoff_layer *layer;
 };
@@ -87,7 +113,7 @@ device_test_commit(struct liftoff_device *device, drmModeAtomicReq *req,
 		   uint32_t flags);
 
 struct liftoff_layer_property *
-layer_get_property(struct liftoff_layer *layer, const char *name);
+layer_get_property(struct liftoff_layer *layer, enum liftoff_core_property prop);
 
 void
 layer_get_rect(struct liftoff_layer *layer, struct liftoff_rect *rect);
@@ -113,5 +139,8 @@ plane_apply(struct liftoff_plane *plane, struct liftoff_layer *layer,
 
 void
 output_log_layers(struct liftoff_output *output);
+
+ssize_t
+core_property_index(const char *name);
 
 #endif


### PR DESCRIPTION
This is a set of well-known KMS standard properties, either used
by libliftoff itself or commonly used by compositors. Adding
special cases for these allows us to access them without having
to iterate over a list.

This roughly improves performance by ~50% when leaving out the
atomic test-only commits.

- [ ] Consider reserving the first items of the props array for the core props

Closes: https://github.com/emersion/libliftoff/issues/1